### PR TITLE
Accept any type that can be turned into a path reference for load

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -1,14 +1,15 @@
-use std::ffi::OsStr;
+use std::convert::AsRef;
 use std::fs::File;
 use std::io::Read;
+use std::path::Path;
 
-pub fn load(filename: &OsStr) -> Result<String, String> {
-    let mut file = match File::open(filename) {
+pub fn load<P: AsRef<Path>>(path: P) -> Result<String, String> {
+    let mut file = match File::open(&path) {
         Ok(file) => file,
         Err(error) => {
             return Err(format!(
                 "Error while loading {}: {}\n",
-                filename.to_string_lossy(),
+                path.as_ref().display(),
                 error
             ))
         }


### PR DESCRIPTION
This commit makes `a2lfile::load` more flexible in what it accepts as type for a file path. This includes `&str`, `&OsStr`, `&OsString`, `&String` and `&Path`. [See](https://doc.rust-lang.org/std/path/struct.Path.html#impl-AsRef%3CPath%3E) for more details.

The change is unlikely to break existing code in practice, i.e.,

```rust
a2lfile::load(&std::ffi::OsString::from("example.a2l"), ...);
```

still works.

The downside, of course, is that it makes the type signature more complicated, but it's the same type signature as [`File::open`](https://doc.rust-lang.org/std/fs/struct.File.html#method.open).