### PR TITLE
Add file path option to follow include in Tokenizer

### DIFF
--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -132,7 +132,9 @@ pub(crate) fn tokenize(
                 line,
             });
             separated = false;
-        } else if tokens.last().unwrap().ttype == A2lTokenType::Include && !(filebytes[bytepos]).is_ascii_digit() && is_identchar(filebytes[bytepos]) {
+        } else if !tokens.is_empty() &&
+        tokens.last().unwrap().ttype == A2lTokenType::Include && 
+        !(filebytes[bytepos]).is_ascii_digit() && is_identchar(filebytes[bytepos]) {
             // a file path
             separator_check(separated, line)?;
             while bytepos < datalen && is_pathchar(filebytes[bytepos]) {

--- a/src/tokenizer.rs
+++ b/src/tokenizer.rs
@@ -636,4 +636,26 @@ ASAP2_VERSION 1 60
         assert_eq!(tokresult.tokens[0].ttype, A2lTokenType::Identifier);
         assert_eq!(tokresult.tokens[13].ttype, A2lTokenType::String); // a2ml body text
     }
+
+    #[test]
+    fn tokenize_include(){
+        let data = String::from(
+            r##"
+                /include ./tests/test.a2l
+                /include .\tests\test.a2l
+                /include ".\tests\test.a2l"
+                /include "./tests/test.a2l"
+            "##
+        );
+
+        let tokresult = tokenize("testcase".to_string(), 0, &data).expect("Error");
+        println!("token count: {}", tokresult.tokens.len());
+        println!("file count: {}", tokresult.filenames.len());
+        assert_eq!(tokresult.tokens.len(), 0);
+        assert_eq!(tokresult.filenames.len(), 5); // original filename and each include
+        assert_eq!(tokresult.filenames[1], "./tests/test.a2l");
+        assert_eq!(tokresult.filenames[2], ".\\tests\\test.a2l");
+        assert_eq!(tokresult.filenames[1], "./tests/test.a2l");
+        assert_eq!(tokresult.filenames[2], ".\\tests\\test.a2l");
+    }
 }


### PR DESCRIPTION
This is to allow the tokenizer to cope with relative include paths that aren't in quote marks, it isn't required by the standard and isn't always in generated A2Ls (depending on software)