### PR TITLE
find_string_end handles double quote escapes correctly + version bumpt to 1.3.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "a2lfile"
-version = "1.3.3"
+version = "1.3.4"
 authors = ["Daniel Thaler <daniel@dthaler.de>"]
 edition = "2021"
 description = "read, modify and write a2l files"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-a2lfile = "1.3.2"
+a2lfile = "1.3.4"
 ```
 
 A simple program based on the `a2lfile` library might look like this:


### PR DESCRIPTION
fixes issue #17 
