### PR TITLE
detect invalid identifiers that start with a number

### DIFF
--- a/a2lmacros/src/a2lspec.rs
+++ b/a2lmacros/src/a2lspec.rs
@@ -21,8 +21,7 @@ pub(crate) fn a2l_specification(tokens: TokenStream) -> TokenStream {
 
     let types = build_typelist(structs, enums);
 
-    let mut typesvec: Vec<(&String, &DataItem)> =
-        types.iter().map(|(key, val)| (key, val)).collect();
+    let mut typesvec: Vec<(&String, &DataItem)> = types.iter().collect();
     typesvec.sort_by(|a, b| a.0.cmp(b.0));
 
     let mut result = TokenStream::new();

--- a/a2lmacros/src/a2mlspec.rs
+++ b/a2lmacros/src/a2mlspec.rs
@@ -37,8 +37,7 @@ pub(crate) fn a2ml_specification(tokens: TokenStream) -> TokenStream {
     result.extend(generate_a2ml_constant(&spec));
     let outtypes = fixup_output_datatypes(&spec);
 
-    let mut typesvec: Vec<(&String, &DataItem)> =
-        outtypes.iter().map(|(key, val)| (key, val)).collect();
+    let mut typesvec: Vec<(&String, &DataItem)> = outtypes.iter().collect();
     typesvec.sort_by(|a, b| a.0.cmp(b.0));
 
     for (typename, a2mltype) in typesvec {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub use a2ml::{GenericIfData, GenericIfDataTaggedItem};
 pub use specification::*;
 
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum A2lError {
     /// FileOpenError: An IoError that occurred while loading a file
     #[error("Failed to load {filename}: {ioerror}")]
@@ -192,7 +193,7 @@ fn load_impl(
         });
     }
 
-    let firstline = tokenresult.tokens.get(0).map(|tok| tok.line).unwrap_or(1);
+    let firstline = tokenresult.tokens.first().map(|tok| tok.line).unwrap_or(1);
     // create a context for the parser
     let context = ParseContext {
         element: "A2L_FILE".to_string(),
@@ -278,7 +279,7 @@ pub fn load_fragment(a2ldata: &str) -> Result<Module, A2lError> {
     // tokenize the input data
     let tokenresult = tokenizer::tokenize("(fragment)".to_string(), 0, &fixed_a2ldata)
         .map_err(|tokenizer_error| A2lError::TokenizerError { tokenizer_error })?;
-    let firstline = tokenresult.tokens.get(0).map(|tok| tok.line).unwrap_or(1);
+    let firstline = tokenresult.tokens.first().map(|tok| tok.line).unwrap_or(1);
     let context = ParseContext {
         element: "MODULE".to_string(),
         fileid: 0,

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,6 +1,5 @@
 use std::cmp::Ordering;
 use std::collections::HashSet;
-use std::convert::TryInto;
 use std::fmt::Write;
 
 use crate::specification::BlockInfo;
@@ -84,7 +83,7 @@ impl Writer {
     where
         T: std::convert::Into<f64>,
     {
-        let value_conv = value.try_into().unwrap();
+        let value_conv = value.into();
         self.add_whitespace(offset);
         if value_conv == 0f64 {
             self.outstring.push('0');


### PR DESCRIPTION
This case now gives a ParserError::InvalidIdentifier instead of a MissingWhitespace from the tokenizer. The error is converted to a warning if strict standard compliance is turned off during loading.

Fixes #23