### PR TITLE
use error type for A2lFile.write() as well

### DIFF
--- a/src/writer.rs
+++ b/src/writer.rs
@@ -32,7 +32,7 @@ impl Writer {
         }
     }
 
-    // add a string to the outout and prefix it with whitespace
+    // add a string to the output and prefix it with whitespace
     pub(crate) fn add_str(&mut self, text: &str, offset: u32) {
         self.add_whitespace(offset);
         self.outstring.push_str(text);


### PR DESCRIPTION
following up the change in 1.4.0, this is a conversion to thiserror for write() api.

This is a breaking change.

I also changed a bit the other part of the error handling to be consistent in the use of map_err