### PR TITLE
replace bunch of get(x).is_some() by contains(x)

### DIFF
--- a/src/cleanup/compu_methods.rs
+++ b/src/cleanup/compu_methods.rs
@@ -98,7 +98,7 @@ fn remove_unused_compumethods(module: &mut Module) {
 
     module
         .compu_method
-        .retain(|item| used_compumethods.get(&item.name).is_some());
+        .retain(|item| used_compumethods.contains(&item.name));
 }
 
 fn remove_unused_sub_elements(module: &mut Module) {
@@ -117,13 +117,13 @@ fn remove_unused_sub_elements(module: &mut Module) {
 
     module
         .compu_tab
-        .retain(|item| used_compu_tabs.get(&item.name).is_some());
+        .retain(|item| used_compu_tabs.contains(&item.name));
     module
         .compu_vtab
-        .retain(|item| used_compu_tabs.get(&item.name).is_some());
+        .retain(|item| used_compu_tabs.contains(&item.name));
     module
         .compu_vtab_range
-        .retain(|item| used_compu_tabs.get(&item.name).is_some());
+        .retain(|item| used_compu_tabs.contains(&item.name));
 
     // remove all unused UNITs
     for unit in &module.unit {
@@ -134,7 +134,7 @@ fn remove_unused_sub_elements(module: &mut Module) {
 
     module
         .unit
-        .retain(|item| used_units.get(&item.name).is_some());
+        .retain(|item| used_units.contains(&item.name));
 }
 
 fn remove_invalid_sub_element_refs(module: &mut Module) {

--- a/src/cleanup/functions.rs
+++ b/src/cleanup/functions.rs
@@ -146,7 +146,7 @@ fn remove_broken_func_refs(module: &mut Module) {
         if let Some(function_list) = &mut axispts.function_list {
             function_list
                 .name_list
-                .retain(|name| existing_functions.get(name).is_some());
+                .retain(|name| existing_functions.contains(name));
         }
     }
 
@@ -154,7 +154,7 @@ fn remove_broken_func_refs(module: &mut Module) {
         if let Some(function_list) = &mut chara.function_list {
             function_list
                 .name_list
-                .retain(|name| existing_functions.get(name).is_some());
+                .retain(|name| existing_functions.contains(name));
         }
     }
 
@@ -162,7 +162,7 @@ fn remove_broken_func_refs(module: &mut Module) {
         if let Some(function_list) = &mut meas.function_list {
             function_list
                 .name_list
-                .retain(|name| existing_functions.get(name).is_some());
+                .retain(|name| existing_functions.contains(name));
         }
     }
 
@@ -170,7 +170,7 @@ fn remove_broken_func_refs(module: &mut Module) {
         if let Some(function_list) = &mut group.function_list {
             function_list
                 .name_list
-                .retain(|name| existing_functions.get(name).is_some());
+                .retain(|name| existing_functions.contains(name));
         }
     }
 
@@ -178,7 +178,7 @@ fn remove_broken_func_refs(module: &mut Module) {
         if let Some(sub_functions) = &mut function.sub_function {
             sub_functions
                 .identifier_list
-                .retain(|name| existing_functions.get(name).is_some());
+                .retain(|name| existing_functions.contains(name));
         }
     }
 }
@@ -210,27 +210,27 @@ fn remove_broken_object_refs(module: &mut Module) {
         if let Some(ref_characteristic) = &mut func.ref_characteristic {
             ref_characteristic
                 .identifier_list
-                .retain(|ident| object_names.get(ident).is_some());
+                .retain(|ident| object_names.contains(ident));
         }
         if let Some(def_characteristic) = &mut func.def_characteristic {
             def_characteristic
                 .identifier_list
-                .retain(|ident| object_names.get(ident).is_some());
+                .retain(|ident| object_names.contains(ident));
         }
         if let Some(in_measurement) = &mut func.in_measurement {
             in_measurement
                 .identifier_list
-                .retain(|ident| object_names.get(ident).is_some());
+                .retain(|ident| object_names.contains(ident));
         }
         if let Some(loc_measurement) = &mut func.loc_measurement {
             loc_measurement
                 .identifier_list
-                .retain(|ident| object_names.get(ident).is_some());
+                .retain(|ident| object_names.contains(ident));
         }
         if let Some(out_measurement) = &mut func.out_measurement {
             out_measurement
                 .identifier_list
-                .retain(|ident| object_names.get(ident).is_some());
+                .retain(|ident| object_names.contains(ident));
         }
     }
 }

--- a/src/cleanup/groups.rs
+++ b/src/cleanup/groups.rs
@@ -20,7 +20,7 @@ fn remove_invalid_object_references(module: &mut Module) {
             // retain only references to existing characteristics
             ref_characteristic
                 .identifier_list
-                .retain(|item| refnames.get(item).is_some());
+                .retain(|item| refnames.contains(item));
             if ref_characteristic.identifier_list.is_empty() {
                 grp.ref_characteristic = None;
             }
@@ -29,7 +29,7 @@ fn remove_invalid_object_references(module: &mut Module) {
             // retain only references to existing measurements
             ref_measurement
                 .identifier_list
-                .retain(|item| refnames.get(item).is_some());
+                .retain(|item| refnames.contains(item));
             if ref_measurement.identifier_list.is_empty() {
                 grp.ref_measurement = None;
             }

--- a/src/cleanup/record_layouts.rs
+++ b/src/cleanup/record_layouts.rs
@@ -20,9 +20,8 @@ pub(crate) fn cleanup(module: &mut Module) {
             used_record_layouts.insert(s_rec_layout.name.to_owned());
         }
     }
-
     // remove all unused RECORD_LAYOUTs
     module
         .record_layout
-        .retain(|item| used_record_layouts.get(&item.name).is_some());
+        .retain(|item| used_record_layouts.contains(&item.name));
 }


### PR DESCRIPTION
was doing some cleanup algorithms on my a2l files, and found out that there is more or less same algorithm already in the public a2lfile api, but implemented with get(x).is_some()

It is actually implemented the same at low level, but this is a arguably  more idiomatic