### PR TITLE
feat: export namemap enums

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@ mod specification;
 mod tokenizer;
 mod writer;
 
-pub use namemap::ModuleNameMap;
+pub use namemap::{ModuleNameMap, NameMapCompuTab, NameMapObject, NameMapTypedef};
 pub use parser::ParserError;
 use std::convert::AsRef;
 use std::fmt::Write;


### PR DESCRIPTION
In order to actually use the maps in pattern matching, we need to be able to import those enum
but namemap module is private.

If you prefer namemap to be public, that's an alternative