### PR TITLE
Add support for /include in a2ml grammar

### DIFF
--- a/a2lfile/src/ifdata.rs
+++ b/a2lfile/src/ifdata.rs
@@ -753,7 +753,8 @@ mod ifdata_test {
             &mut log_msgs,
             false,
         );
-        parser.builtin_a2mlspec = Some(a2lfile::a2ml::parse_a2ml(A2MLTEST_TEXT).unwrap());
+
+        parser.builtin_a2mlspec = Some(a2lfile::a2ml::parse_a2ml(None, A2MLTEST_TEXT).unwrap().0);
         super::parse_ifdata(
             &mut parser,
             &a2lfile::ParseContext {

--- a/a2lfile/src/lib.rs
+++ b/a2lfile/src/lib.rs
@@ -206,8 +206,8 @@ fn load_impl(
     // if a built-in A2ml specification was passed as a string, then it is parsed here
     if let Some(spec) = a2ml_spec {
         parser.builtin_a2mlspec = Some(
-            a2ml::parse_a2ml(&spec)
-                .map_err(|parse_err| A2lError::InvalidBuiltinA2mlSpec { parse_err })?,
+            a2ml::parse_a2ml(Some(path.to_string_lossy().to_string()), &spec)
+                .map_err(|parse_err| A2lError::InvalidBuiltinA2mlSpec { parse_err })?.0,
         );
     }
 

--- a/a2lfile/src/loader.rs
+++ b/a2lfile/src/loader.rs
@@ -1,7 +1,51 @@
+use std::ffi::OsString;
 use crate::A2lError;
 use std::fs::File;
 use std::io::Read;
 use std::path::Path;
+
+// is_numchar()
+// in addition to decimal format, numbers can also be written as hex, or as floats with exponents
+// this expands the set of allowable characters beyond is_ascii_hexdigit()
+pub fn is_numchar_u8(c: u8) -> bool {
+    c.is_ascii_hexdigit() || c == b'x' || c == b'X' || c == b'.' || c == b'+' || c == b'-'
+}
+
+
+// is_identchar()
+// is this char allowed in an identifier
+pub fn is_identchar(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '.' || c == '_'
+}
+
+// u8 version of the above function
+pub fn is_identchar_u8(c: u8) -> bool {
+    c.is_ascii_alphanumeric() || c == b'.' || c == b'[' || c == b']' || c == b'_'
+}
+
+// is_pathchar()
+// is this char allowed in a file path, extension of is_identchar()
+pub fn is_pathchar(c: char) -> bool {
+    is_identchar(c) || c == '\\' || c == '/'
+}
+
+// u8 version of the above function
+pub fn is_pathchar_u8(c: u8) -> bool {
+    is_identchar_u8(c) || c == b'\\' || c == b'/'
+}
+
+pub fn make_include_filename(incname: &str, base_filename: &str) -> OsString {
+    let base = std::path::Path::new(base_filename);
+    if let Some(basedir) = base.parent() {
+        let joined = basedir.join(incname);
+        if joined.exists() {
+            return OsString::from(joined);
+        }
+    }
+
+    OsString::from(incname)
+}
+
 
 pub fn load(path: &Path) -> Result<String, A2lError> {
     let mut file = match File::open(path) {

--- a/a2lfile/tests/test.rs
+++ b/a2lfile/tests/test.rs
@@ -82,6 +82,7 @@ ASAP2_VERSION 1 61
 
         a2l_file.a2ml_version = Some(A2mlVersion::new(1, 31));
 
+        let merged_a2ml_text = String::from("");
         let a2ml = A2ml::new(
             r##"  block "IF_DATA" taggedunion if_data {
             block "BLOCK_A" struct {
@@ -93,6 +94,7 @@ ASAP2_VERSION 1 61
         };
         "##
             .to_string(),
+            merged_a2ml_text
         );
 
         let mut if_data_a = IfData::new();
@@ -1207,12 +1209,14 @@ ASAP2_VERSION 1 61
         let module = &mut a2l_file5.project.module[0];
         module.name = "mod".to_string();
         module.long_identifier = "long_identifier".to_string();
+        let merged_a2ml_text = String::from("");
         module.a2ml = Some(A2ml::new(
             r#"
                     block "IF_DATA" struct {
                         int;
                     };"#
             .to_string(),
+            merged_a2ml_text
         ));
         let mut axis_pts = AxisPts::new(
             "axispts_name".to_string(),

--- a/a2lmacros/src/a2mlspec.rs
+++ b/a2lmacros/src/a2mlspec.rs
@@ -1364,7 +1364,7 @@ fn generate_interface(spec: &A2mlSpec) -> TokenStream {
             pub(crate) fn update_a2ml(file: &mut a2lfile::A2lFile) {
                 for module in &mut file.project.module {
                     if module.a2ml.is_none() {
-                        module.a2ml = Some(a2lfile::A2ml::new("".to_string()));
+                        module.a2ml = Some(a2lfile::A2ml::new("".to_string(), "".to_string()));
                     }
                     module.a2ml.as_mut().unwrap().a2ml_text = #constname.to_string();
                 }


### PR DESCRIPTION
The goal is to add the following capabilities in the tool:
- support /include in a2ml grammar
- support merging this /include in the output file

notes:
- still in development, but the overall structure is here and i am opening this PR to get an early feedback on the architecture of this new feature, specifically on the following points:
-- changed &str to String in the a2ml token enum (this was done to not store the whole include file content)
-- in order to support merging the includes, i have stored the expanded string in the A2lfile a2ml_spec so when merging is requested, i just switched the data to write
- still working on the validation