### PR TITLE
feat: add more unit tests for float parsing

### DIFF
--- a/a2lfile/src/parser.rs
+++ b/a2lfile/src/parser.rs
@@ -1120,7 +1120,7 @@ mod tests {
 
     #[test]
     fn parsing_numbers_test() {
-        let input_text = r##"0 0x1 1.0e+2 1000 0 0.1 0x11 1.0e+2"##;
+        let input_text = r##"0 0x1 1.0e+2 1000 0 0.1 0x11 1.0e+2 0X1f 0X2F 2F F"##;
         let tokenresult = tokenizer::tokenize(&Filename::from("test_input"), 0, input_text);
         assert!(tokenresult.is_ok());
 
@@ -1177,6 +1177,27 @@ mod tests {
         assert!(res.is_ok());
         let val = res.unwrap();
         assert_eq!(val, 100f32);
+
+        // float: 0X1f
+        let res = parser.get_float(&context);
+        assert!(res.is_ok());
+        let val = res.unwrap();
+        assert_eq!(val, 31f32);
+
+        // float: 0X2F
+        let res = parser.get_float(&context);
+        assert!(res.is_ok());
+        let val = res.unwrap();
+        assert_eq!(val, 47f32);
+
+        // float: 2F
+        let res = parser.get_float(&context);
+        assert!(res.is_err());
+
+        // float: F
+        let res = parser.get_float(&context);
+        assert!(res.is_err());
+
     }
 
     #[test]

--- a/a2lfile/src/parser.rs
+++ b/a2lfile/src/parser.rs
@@ -598,6 +598,9 @@ impl<'a> ParserState<'a> {
     pub(crate) fn get_float(&mut self, context: &ParseContext) -> Result<f32, ParserError> {
         let token = self.expect_token(context, A2lTokenType::Number)?;
         let text = self.get_token_text(token);
+        // some vendor tools are defining the characteristic UpperLimit and LowerLimit
+        // (float values from specifications) using 0xNNN for characteristics that
+        // are actually integers.
         if text.starts_with("0x") || text.starts_with("0X") {
             match u64::from_str_radix(&text[2..], 16) {
                 Ok(num) => Ok(num as f32),
@@ -617,6 +620,9 @@ impl<'a> ParserState<'a> {
     pub(crate) fn get_double(&mut self, context: &ParseContext) -> Result<f64, ParserError> {
         let token = self.expect_token(context, A2lTokenType::Number)?;
         let text = self.get_token_text(token);
+        // some vendor tools are defining the characteristic UpperLimit and LowerLimit
+        // (float values from specifications) using 0xNNN for characteristics that
+        // are actually integers.
         if text.starts_with("0x") || text.starts_with("0X") {
             match u64::from_str_radix(&text[2..], 16) {
                 Ok(num) => Ok(num as f64),


### PR DESCRIPTION
the float parser change had removed some negative tests.

reintroduced some negative tests, and some more formatting tests.