### PR TITLE
Add the ability to refer to a TYPEDEF_AXIS using THIS

### DIFF
--- a/a2lfile/src/checker.rs
+++ b/a2lfile/src/checker.rs
@@ -30,7 +30,32 @@ pub fn check(a2l_file: &A2lFile) -> Vec<A2lError> {
         }
 
         for t_characteristic in &module.typedef_characteristic {
-            check_typedef_characteristic(t_characteristic, &name_map, &mut results);
+            // a TYPEDEF_CHARACTERISTIC is directly used if it is used in an INSTANCE
+            // indirect use is if it is used as a STRUCTURE_COMPONENT in a TYPEDEF_STRUCTURE
+            // directly used TYPEDEF_CHARACTERISTICs cannot use THIS
+            let is_directly_used = module
+                .instance
+                .iter()
+                .any(|instance| instance.type_ref == t_characteristic.name);
+            // build a list of TYPEDEF_STRUCTUREs that use this TYPEDEF_CHARACTERISTIC as a STRUCTURE_COMPONENT
+            // indirectly used TYPEDEF_CHARACTERISTICs can use THIS in their AXIS_DESCRs to refer to the
+            // containing structure
+            let containing_structures: Vec<&TypedefStructure> = module
+                .typedef_structure
+                .iter()
+                .filter(|ts| {
+                    ts.structure_component
+                        .iter()
+                        .any(|sc| sc.component_type == t_characteristic.name)
+                })
+                .collect();
+            check_typedef_characteristic(
+                t_characteristic,
+                &name_map,
+                &mut results,
+                is_directly_used,
+                &containing_structures,
+            );
         }
 
         for compu_method in &module.compu_method {
@@ -76,6 +101,8 @@ fn check_axis_descr(
     axis_descr: &AxisDescr,
     name_map: &ModuleNameMap,
     log_msgs: &mut Vec<A2lError>,
+    is_directly_used: bool,
+    containing_structures: &[&TypedefStructure],
 ) {
     let line = axis_descr.get_line();
     if axis_descr.input_quantity != "NO_INPUT_QUANTITY"
@@ -126,7 +153,23 @@ fn check_axis_descr(
 
     if let Some(axis_pts_ref) = &axis_descr.axis_pts_ref {
         let apr_line = axis_pts_ref.get_line();
-        if !name_map.object.contains_key(&axis_pts_ref.axis_points) {
+        if !is_directly_used
+            && !containing_structures.is_empty()
+            && axis_pts_ref.axis_points.starts_with("THIS.")
+        {
+            let structure_component = axis_pts_ref.axis_points.strip_prefix("THIS.").unwrap();
+            // is there any containing structure which does not have a component with the given name?
+            if !is_valid_structure_component(structure_component, containing_structures) {
+                // if so, the THIS reference is invalid
+                log_msgs.push(A2lError::CrossReferenceError {
+                    source_type: format!("AXIS_DESCR[{idx}] of CHARACTERISTIC"),
+                    source_name: parent_name.to_string(),
+                    source_line: apr_line,
+                    target_type: "STRUCTURE_COMPONENT".to_string(),
+                    target_name: structure_component.to_string(),
+                });
+            }
+        } else if !name_map.object.contains_key(&axis_pts_ref.axis_points) {
             log_msgs.push(A2lError::CrossReferenceError {
                 source_type: format!("AXIS_DESCR[{idx}] of CHARACTERISTIC"),
                 source_name: parent_name.to_string(),
@@ -139,7 +182,23 @@ fn check_axis_descr(
 
     if let Some(curve_axis_ref) = &axis_descr.curve_axis_ref {
         let car_line = curve_axis_ref.get_line();
-        if !name_map.object.contains_key(&curve_axis_ref.curve_axis) {
+        if !is_directly_used
+            && !containing_structures.is_empty()
+            && curve_axis_ref.curve_axis.starts_with("THIS.")
+        {
+            let structure_component = curve_axis_ref.curve_axis.strip_prefix("THIS.").unwrap();
+            // is there any containing structure which does not have a component with the given name?
+            if !is_valid_structure_component(structure_component, containing_structures) {
+                // if so, the THIS reference is invalid
+                log_msgs.push(A2lError::CrossReferenceError {
+                    source_type: format!("AXIS_DESCR[{idx}] of CHARACTERISTIC"),
+                    source_name: parent_name.to_string(),
+                    source_line: car_line,
+                    target_type: "STRUCTURE_COMPONENT".to_string(),
+                    target_name: structure_component.to_string(),
+                });
+            }
+        } else if !name_map.object.contains_key(&curve_axis_ref.curve_axis) {
             log_msgs.push(A2lError::CrossReferenceError {
                 source_type: format!("AXIS_DESCR[{idx}] of CHARACTERISTIC"),
                 source_name: parent_name.to_string(),
@@ -149,6 +208,19 @@ fn check_axis_descr(
             });
         }
     }
+}
+
+fn is_valid_structure_component(
+    structure_component: &str,
+    containing_structures: &[&TypedefStructure],
+) -> bool {
+    // all containing structures must have a structure_component with the given name
+    containing_structures.iter().all(|td_struct| {
+        td_struct
+            .structure_component
+            .iter()
+            .any(|sc| sc.component_name == structure_component)
+    })
 }
 
 fn check_typedef_axis(
@@ -271,6 +343,8 @@ fn check_characteristic(
     check_characteristic_common(
         CharacteristicWrapper::Characteristic(characteristic),
         name_map,
+        true, // all CHARACTERISTICs are directly used, indirect use only exists for TYPEDEF_CHARACTERISTICs
+        &[],
         log_msgs,
     );
 
@@ -331,10 +405,14 @@ fn check_typedef_characteristic(
     t_characteristic: &TypedefCharacteristic,
     name_map: &ModuleNameMap,
     log_msgs: &mut Vec<A2lError>,
+    is_directly_used: bool,
+    containing_structures: &[&TypedefStructure],
 ) {
     check_characteristic_common(
         CharacteristicWrapper::TypedefCharacteristic(t_characteristic),
         name_map,
+        is_directly_used,
+        containing_structures,
         log_msgs,
     );
 }
@@ -343,6 +421,8 @@ fn check_typedef_characteristic(
 fn check_characteristic_common(
     characteristic: CharacteristicWrapper,
     name_map: &ModuleNameMap,
+    is_directly_used: bool,
+    containing_structures: &[&TypedefStructure],
     log_msgs: &mut Vec<A2lError>,
 ) {
     let kind = characteristic.kind();
@@ -364,7 +444,15 @@ fn check_characteristic_common(
     }
 
     for (idx, axis_descr) in characteristic.axis_descr().iter().enumerate() {
-        check_axis_descr(idx, name, axis_descr, name_map, log_msgs);
+        check_axis_descr(
+            idx,
+            name,
+            axis_descr,
+            name_map,
+            log_msgs,
+            is_directly_used,
+            containing_structures,
+        );
     }
 
     let expected_axis_count = match characteristic.characteristic_type() {
@@ -1740,5 +1828,52 @@ mod test {
         a2lfile.project.module[0].measurement[0].lower_limit = u32::MIN as f64;
         let log_msgs = super::check(&a2lfile);
         assert_eq!(log_msgs.len(), 0);
+    }
+
+    #[test]
+    fn axis_pts_with_this() {
+        // if an AXIS is defined inside a TYPEDEF_STRUCTURE, then the AXIS_PTS_REF may refer to a structure component using THIS.component_name
+        // valid THIS reference
+        static A2L_TEXT: &str = r#"ASAP2_VERSION 1 71 /begin PROJECT p "" /begin MODULE m ""
+            /begin TYPEDEF_AXIS lookup_axis_type "LookUpTable axis" NO_INPUT_QUANTITY F32 0 NO_COMPU_METHOD 16 -1E32 1E32
+            /end TYPEDEF_AXIS
+            /begin TYPEDEF_CHARACTERISTIC lookup_values_type "LookUpTable values" CURVE F32 0 NO_COMPU_METHOD -1E32 1E32
+                /begin AXIS_DESCR COM_AXIS NO_INPUT_QUANTITY NO_COMPU_METHOD 16 0.0 0.0
+                    AXIS_PTS_REF THIS.lookup_axis
+                    CURVE_AXIS_REF THIS.lookup_axis
+                /end AXIS_DESCR
+            /end TYPEDEF_CHARACTERISTIC
+            /begin TYPEDEF_STRUCTURE LookUpTable "" 128 CONSISTENT_EXCHANGE
+                /begin STRUCTURE_COMPONENT lookup_axis lookup_axis_type 0 /end STRUCTURE_COMPONENT
+                /begin STRUCTURE_COMPONENT lookup_values lookup_values_type 64 /end STRUCTURE_COMPONENT
+            /end TYPEDEF_STRUCTURE
+            /begin INSTANCE lockup_table "" LookUpTable 0x80010000 /end INSTANCE
+            /begin RECORD_LAYOUT F32
+                FNC_VALUES 0 FLOAT32_IEEE ROW_DIR DIRECT
+            /end RECORD_LAYOUT
+        /end MODULE /end PROJECT"#;
+        let (a2lfile, _) = load_from_string(A2L_TEXT, None, true).unwrap();
+        let log_msgs = super::check(&a2lfile);
+        assert_eq!(log_msgs.len(), 0);
+
+        // invalid THIS reference
+        static A2L_TEXT2: &str = r#"ASAP2_VERSION 1 71 /begin PROJECT p "" /begin MODULE m ""
+            /begin TYPEDEF_CHARACTERISTIC lookup_values_type "LookUpTable values" CURVE F32 0 NO_COMPU_METHOD -1E32 1E32
+                /begin AXIS_DESCR COM_AXIS NO_INPUT_QUANTITY NO_COMPU_METHOD 16 0.0 0.0
+                    AXIS_PTS_REF THIS.lookup_axis
+                    CURVE_AXIS_REF THIS.lookup_axis
+                /end AXIS_DESCR
+            /end TYPEDEF_CHARACTERISTIC
+            /begin TYPEDEF_STRUCTURE LookUpTable "" 128 CONSISTENT_EXCHANGE
+                /begin STRUCTURE_COMPONENT lookup_values lookup_values_type 64 /end STRUCTURE_COMPONENT
+            /end TYPEDEF_STRUCTURE
+            /begin INSTANCE lockup_table "" LookUpTable 0x80010000 /end INSTANCE
+            /begin RECORD_LAYOUT F32
+                FNC_VALUES 0 FLOAT32_IEEE ROW_DIR DIRECT
+            /end RECORD_LAYOUT
+        /end MODULE /end PROJECT"#;
+        let (a2lfile, _) = load_from_string(A2L_TEXT2, None, true).unwrap();
+        let log_msgs = super::check(&a2lfile);
+        assert_eq!(log_msgs.len(), 2);
     }
 }

--- a/a2lfile/src/namemap.rs
+++ b/a2lfile/src/namemap.rs
@@ -29,6 +29,43 @@ pub enum NameMapTypedef<'a> {
     TypedefStructure(&'a TypedefStructure),
 }
 
+impl<'a> NameMapTypedef<'a> {
+    pub fn blob(&self) -> Option<&'a TypedefBlob> {
+        match self {
+            Self::TypedefBlob(blob) => Some(blob),
+            _ => None,
+        }
+    }
+
+    pub fn axis(&self) -> Option<&'a TypedefAxis> {
+        match self {
+            Self::TypedefAxis(axis) => Some(axis),
+            _ => None,
+        }
+    }
+
+    pub fn measurement(&self) -> Option<&'a TypedefMeasurement> {
+        match self {
+            Self::TypedefMeasurement(measurement) => Some(measurement),
+            _ => None,
+        }
+    }
+
+    pub fn characteristic(&self) -> Option<&'a TypedefCharacteristic> {
+        match self {
+            Self::TypedefCharacteristic(characteristic) => Some(characteristic),
+            _ => None,
+        }
+    }
+
+    pub fn structure(&self) -> Option<&'a TypedefStructure> {
+        match self {
+            Self::TypedefStructure(structure) => Some(structure),
+            _ => None,
+        }
+    }
+}
+
 macro_rules! check_and_insert {
     ( $hash:expr, $key:expr, $item:expr, $log_msgs:expr, $blockname:expr ) => {
         if let Some(existing_val) = $hash.get(&$key) {


### PR DESCRIPTION
Specifically, if an AXIS is defined inside a TYPEDEF_STRUCTURE, then the AXIS_PTS_REF may refer to a structure component using THIS.component_name.

Fixes #39