### PR TITLE
CALIBRATION_HANDLE may appear more than once in CALIBRATION_METHOD

### DIFF
--- a/a2lfile/src/specification.rs
+++ b/a2lfile/src/specification.rs
@@ -5709,7 +5709,7 @@ impl ParseableA2lObject for CalibrationMethod {
                 "CALIBRATION_HANDLE" => {
                     parser.require_block(tag, is_block, context)?;
                     let newitem = CalibrationHandle::parse(parser, &newcontext, line_offset)?;
-                    parser.handle_multiplicity_error(context, tag, calibration_handle.is_some())?;
+                    //parser.handle_multiplicity_error(context, tag, calibration_handle.is_some())?;
                     calibration_handle = Some(newitem);
                 }
                 _ => {

--- a/a2lfile/src/specification_orig.rs
+++ b/a2lfile/src/specification_orig.rs
@@ -52,7 +52,11 @@ pub(crate) trait PositionRestricted {
 }
 
 pub(crate) trait ParseableA2lObject: Sized {
-    fn parse(parser: &mut ParserState, context: &ParseContext, start_offset: u32) -> Result<Self, ParserError>;
+    fn parse(
+        parser: &mut ParserState,
+        context: &ParseContext,
+        start_offset: u32,
+    ) -> Result<Self, ParserError>;
 }
 
 a2l_specification! {
@@ -377,7 +381,7 @@ a2l_specification! {
     /// calibration method specific data
     block CALIBRATION_HANDLE {
         {long handle}* handle_list
-        [-> CALIBRATION_HANDLE_TEXT] (1.60 ..)
+        [-> CALIBRATION_HANDLE_TEXT]* (1.60 ..)
     }
 
     /// Additional text for a calibration handle
@@ -393,7 +397,7 @@ a2l_specification! {
     block CALIBRATION_METHOD {
         string method
         ulong version
-        [-> CALIBRATION_HANDLE]
+        [-> CALIBRATION_HANDLE]*
     }
 
     /// Specifies the type of an adjustable object

--- a/a2lmacros/src/lib.rs
+++ b/a2lmacros/src/lib.rs
@@ -397,7 +397,7 @@ mod test {
         /// calibration method specific data
         block CALIBRATION_HANDLE {
             {long handle}* handle_list
-            [-> CALIBRATION_HANDLE_TEXT] (1.60 ..)
+            [-> CALIBRATION_HANDLE_TEXT]* (1.60 ..)
         }
 
         /// Additional text for a calibration handle
@@ -413,7 +413,7 @@ mod test {
         block CALIBRATION_METHOD {
             string method
             ulong version
-            [-> CALIBRATION_HANDLE]
+            [-> CALIBRATION_HANDLE]*
         }
 
         /// Specifies the type of an adjustable object


### PR DESCRIPTION
Hi Daniel,

I have a lot of files with multiple CALIBRATION_HANDLE in CALIBRATION_METHOD.
I do not fully understand the code, but these changes solved the problem for me.

I have checked the  reader with several 1000 files from our test pools.
This was the most significant cause of error.

Regards
Rainer