### PR TITLE
modify get_line_offset to deal with a non-comment token in a same lin…

### DIFF
--- a/a2lfile/src/parser.rs
+++ b/a2lfile/src/parser.rs
@@ -434,10 +434,14 @@ impl<'a> ParserState<'a> {
     /// - the function shouldn't be called while pos == 0, but this case would behave like pos==1
     pub(crate) fn get_line_offset(&self) -> u32 {
         if self.token_cursor.pos > 1 && self.token_cursor.pos < self.token_cursor.tokens.len() {
-            let prev_line = self.token_cursor.tokens[self.token_cursor.pos - 2].line;
-            let prev_fileid = self.token_cursor.tokens[self.token_cursor.pos - 2].fileid;
-            let cur_line = self.token_cursor.tokens[self.token_cursor.pos - 1].line;
-            let cur_fileid = self.token_cursor.tokens[self.token_cursor.pos - 1].fileid;
+            let prev_token = &self.token_cursor.tokens[self.token_cursor.pos - 2];
+            let cur_token = &self.token_cursor.tokens[self.token_cursor.pos - 1];
+            let (prev_line, prev_fileid) = if self.token_cursor.pos > 2 
+                && prev_token.line == cur_token.line && prev_token.ttype == A2lTokenType::Comment{
+                (self.token_cursor.tokens[self.token_cursor.pos - 3].line, self.token_cursor.tokens[self.token_cursor.pos - 3].fileid)
+            } else {(prev_token.line, prev_token.fileid)};
+            let cur_line = cur_token.line;
+            let cur_fileid = cur_token.fileid;
 
             // subtracting line numbers is only sane within a file
             if prev_fileid == cur_fileid {


### PR DESCRIPTION
If there is a block like this:
```
/begin CHARACTERISTIC
      /* Name                   */      xxxxxxxxxxxxx
      /* Long Identifier        */      "xxxxxxx"
      /* Type                   */      VALUE 
      /* ECU Address            */      0x0000 /* @ECU_Address@xxxxxxxx@ */ 
      /* Record Layout          */      Scalar_FLOAT32_IEEE 
      /* Maximum Difference     */      0 
      /* Conversion Method      */      single 
      /* Lower Limit            */      -3.4E+38 
      /* Upper Limit            */      3.4E+38
/end CHARACTERISTIC`

```
when using a2ltool merge it will transform to the following format, in one line:
```
/begin CHARACTERISTIC xxxxxxxxxxxxx "xxxxxxx" VALUE 0x0000 Scalar_FLOAT32_IEEE 0 single 0 1
    /end CHARACTERISTIC
```

this pull request will resolve this problem.